### PR TITLE
Update index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset='utf-8' />
     <meta http-equiv="X-UA-Compatible" content="chrome=1" />
-    <title>Redirecting to https://github.com/FontManager/font-manager</title>
+    <title>GTK FontManager</title>
     <meta http-equiv="refresh" content="0; URL=https://github.com/FontManager/font-manager">
     <link rel="canonical" href="https://github.com/FontManager/font-manager">
     <link href='https://fonts.googleapis.com/css?family=Chivo:900' rel='stylesheet' type='text/css' />
@@ -29,7 +29,8 @@
         <section id="main_content">
           <p>
             <img src="https://raw.githubusercontent.com/FontManager/resources/master/font-manager.png" alt="Screenshot" />
-            Font Manager is intended to provide a way for average users to easily manage desktop fonts, without having to resort to command line tools or editing configuration files by hand. While designed primarily with the Gnome Desktop Environment in mind, it should work well with other Gtk+ desktop environments.
+            Font Manager is intended to provide a way for average users to easily manage desktop fonts, without having to resort to command line tools or editing configuration files by hand.
+            While designed primarily with the Gnome Desktop Environment in mind, it should work well with other Gtk+ desktop environments.
           </p>
           <p>
             Font Manager is NOT a professional-grade font management solution.
@@ -112,9 +113,9 @@
             <header>
               <h2>Source Code</h2>
             </header>
-            <a href="https://github.com/FontManager/font-manager/releases/download/0.8.3/font-manager-0.8.3.tar.xz" id="download" class="button"><span>Version 0.8.3</span></a>
+            <a href="https://github.com/FontManager/font-manager/releases/latest"><span>Release</span></a>
             <a href="https://github.com/FontManager/master/zipball/master" id="download" class="button"><span>Current</span></a>
-            <a href="https://github.com/FontManager/master" id="view-on-github" class="button"><span>View on GitHub</span></a>
+            <a href="https://github.com/FontManager/font-manager" id="view-on-github" class="button"><span>View on GitHub</span></a>
           </section>
         </footer>
 


### PR DESCRIPTION
In https://github.com/FontManager/font-manager/issues/259 @JerryCasiano said, 

> are you volunteering to update and maintain a separate site going forward?

But it seems the only part of the site that needs to be maintained is the link to the release; this commit removes the redirect, and replaces the link that gets outdated with an evergreen link.

Please let me know if there's anything else that needs to be updated; I expect it could be automated.
